### PR TITLE
Add sql commands for OMOP CDM ddl staging tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ You can also import the vocabulary outside of Terraform, which can drastically i
 
 To import the vocabulary and synthetic data manually, be sure to comment out the vocab and data import in the Terraform `main.tf` script (lines 153-156 and lines 163-166, respectively) and use the script `vocab_import.sh` and `synpuf_data_import.sh`, respectively, in the `\scripts` directory. You may need to modify the path to `CSV_FILES` to point to the path of your vocabulary csv files.
 
+### Loading Clinical Data 
+
+[Staging Tables SQL Script](./sql/OMOP_CDM_sql_server_staging_ddl_indexes.sql) is currently executed in the Terraform to aid in loading clinical data into the OMOP CDM database, where, new clinical data can be added to the target staging table and eventually migrated to the permanent clinical table using a SQL Stored Procedure or an alternative approach. You can comment out this import in the Terraform `main.tf` script (lines 154-156) if this isn't desired. 
+
 ## Using Achilles
 
 1. Navigate to `http://{prefix}-{environment}-omop-webtools.azurewebsites.net/`.

--- a/sql/OMOP_CDM_sql_server_staging_ddl.sql
+++ b/sql/OMOP_CDM_sql_server_staging_ddl.sql
@@ -1,0 +1,73 @@
+/**************************
+
+Standardized meta-data
+
+***************************/
+
+SELECT TOP 0 * INTO dbo.staging_cdm_source FROM dbo.cdm_source;
+
+/************************
+
+Standardized clinical data
+
+************************/
+
+SELECT TOP 0 * INTO dbo.staging_condition_occurrence FROM dbo.condition_occurrence;
+
+SELECT TOP 0 * INTO dbo.staging_death FROM dbo.death;
+
+SELECT TOP 0 * INTO dbo.staging_device_exposure FROM dbo.device_exposure;
+
+SELECT TOP 0 * INTO dbo.staging_drug_exposure FROM dbo.drug_exposure;
+
+SELECT TOP 0 * INTO dbo.staging_measurement FROM dbo.measurement;
+
+SELECT TOP 0 * INTO dbo.staging_observation_period FROM dbo.observation_period;
+
+SELECT TOP 0 * INTO dbo.staging_observation FROM dbo.observation;
+
+SELECT TOP 0 * INTO dbo.staging_person FROM dbo.person;
+
+SELECT TOP 0 * INTO dbo.staging_procedure_occurrence FROM dbo.procedure_occurrence;
+
+SELECT TOP 0 * INTO dbo.staging_visit_occurrence FROM dbo.visit_occurrence;
+
+/************************
+
+Standardized health system data
+
+************************/
+
+SELECT TOP 0 * INTO dbo.staging_care_site FROM dbo.care_site;
+
+SELECT TOP 0 * INTO dbo.staging_location FROM dbo.location;
+
+SELECT TOP 0 * INTO dbo.staging_provider FROM dbo.provider;
+
+/************************
+
+Standardized health economics
+
+************************/
+
+SELECT TOP 0 * INTO dbo.staging_cost FROM dbo.cost;
+
+SELECT TOP 0 * INTO dbo.staging_payer_plan_period FROM dbo.payer_plan_period;
+
+/************************
+
+Standardized derived elements
+
+************************/
+
+SELECT TOP 0 * INTO dbo.staging_condition_era FROM dbo.condition_era;
+
+SELECT TOP 0 * INTO dbo.staging_drug_era FROM dbo.drug_era;
+
+
+/************************
+
+Helper Table to move data from staging tables to permanent tables
+
+************************/
+CREATE TABLE watermark_copy_staging_tables (table_name VARCHAR(MAX))

--- a/sql/SPROC_add_indexes_constraints.sql
+++ b/sql/SPROC_add_indexes_constraints.sql
@@ -1,0 +1,790 @@
+CREATE PROCEDURE add_indexes_constraints
+AS
+BEGIN
+        SET NOCOUNT ON; 
+        -- Detect whether the procedure was called  
+        -- from an active transaction and save  
+        -- that for later use.  
+        -- In the procedure, @TranCounter = 0  
+        -- means there was no active transaction  
+        -- and the procedure started one.  
+        -- @TranCounter > 0 means an active  
+        -- transaction was started before the   
+        -- procedure was called. 
+        DECLARE @TranCount INT; 
+        SET @TranCount = @@TRANCOUNT; 
+        DECLARE @PrintMsg VARCHAR(MAX);
+        SET @PrintMsg = 'Before Transaction ' + CAST(@TranCount as varchar(MAX)) ;
+        PRINT(@PrintMsg)
+        IF @TranCount = 0 
+            -- Procedure must start its own  
+            -- transaction.
+            BEGIN TRANSACTION;
+        ELSE
+            -- Procedure called when there is  
+            -- an active transaction.  
+            -- Create a savepoint to be able  
+            -- to roll back only the work done  
+            -- in the procedure if there is an  
+            -- error.
+            SAVE TRANSACTION add_indexes_constraints;
+        BEGIN TRY 
+            -- add indices and primary keys
+            /*********************************************************************************
+            # Copyright 2014 Observational Health Data Sciences and Informatics
+            #
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+            ********************************************************************************/
+
+            /************************
+            ####### #     # ####### ######      #####  ######  #     #           #######      #####     ###
+            #     # ##   ## #     # #     #    #     # #     # ##   ##    #    # #           #     #     #  #    # #####  ###### #    # ######  ####
+            #     # # # # # #     # #     #    #       #     # # # # #    #    # #                 #     #  ##   # #    # #       #  #  #      #
+            #     # #  #  # #     # ######     #       #     # #  #  #    #    # ######       #####      #  # #  # #    # #####    ##   #####   ####
+            #     # #     # #     # #          #       #     # #     #    #    #       # ###       #     #  #  # # #    # #        ##   #           #
+            #     # #     # #     # #          #     # #     # #     #     #  #  #     # ### #     #     #  #   ## #    # #       #  #  #      #    #
+            ####### #     # ####### #           #####  ######  #     #      ##    #####  ###  #####     ### #    # #####  ###### #    # ######  ####
+            sql server script to create the required indexes within OMOP common data model, version 5.3
+            last revised: 14-November-2017
+            author:  Patrick Ryan, Clair Blacketer
+            description:  These primary keys and indices are considered a minimal requirement to ensure adequate performance of analyses.
+            *************************/
+
+
+            /************************
+            *************************
+            *************************
+            *************************
+            Primary key constraints
+            *************************
+            *************************
+            *************************
+            ************************/
+
+
+
+            /************************
+            Standardized vocabulary
+            ************************/
+
+
+
+            ALTER TABLE concept ADD CONSTRAINT xpk_concept PRIMARY KEY NONCLUSTERED (concept_id);
+
+            ALTER TABLE vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY KEY NONCLUSTERED (vocabulary_id);
+
+            ALTER TABLE domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
+
+            ALTER TABLE concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
+
+            ALTER TABLE concept_relationship ADD CONSTRAINT xpk_concept_relationship PRIMARY KEY NONCLUSTERED (concept_id_1,concept_id_2,relationship_id);
+
+            ALTER TABLE relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+
+            ALTER TABLE concept_ancestor ADD CONSTRAINT xpk_concept_ancestor PRIMARY KEY NONCLUSTERED (ancestor_concept_id,descendant_concept_id);
+
+            ALTER TABLE source_to_concept_map ADD CONSTRAINT xpk_source_to_concept_map PRIMARY KEY NONCLUSTERED (source_vocabulary_id,target_concept_id,source_code,valid_end_date);
+
+            ALTER TABLE drug_strength ADD CONSTRAINT xpk_drug_strength PRIMARY KEY NONCLUSTERED (drug_concept_id, ingredient_concept_id);
+
+            ALTER TABLE cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);
+
+            ALTER TABLE attribute_definition ADD CONSTRAINT xpk_attribute_definition PRIMARY KEY NONCLUSTERED (attribute_definition_id);
+
+
+            /**************************
+            Standardized meta-data
+            ***************************/
+
+
+
+            /************************
+            Standardized clinical data
+            ************************/
+
+
+            /**PRIMARY KEY NONCLUSTERED constraints**/
+
+            ALTER TABLE person ADD CONSTRAINT xpk_person PRIMARY KEY NONCLUSTERED ( person_id ) ;
+
+            ALTER TABLE observation_period ADD CONSTRAINT xpk_observation_period PRIMARY KEY NONCLUSTERED ( observation_period_id ) ;
+
+            ALTER TABLE specimen ADD CONSTRAINT xpk_specimen PRIMARY KEY NONCLUSTERED ( specimen_id ) ;
+
+            ALTER TABLE death ADD CONSTRAINT xpk_death PRIMARY KEY NONCLUSTERED ( person_id ) ;
+
+            ALTER TABLE visit_occurrence ADD CONSTRAINT xpk_visit_occurrence PRIMARY KEY NONCLUSTERED ( visit_occurrence_id ) ;
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT xpk_visit_detail PRIMARY KEY NONCLUSTERED ( visit_detail_id ) ;
+
+            ALTER TABLE procedure_occurrence ADD CONSTRAINT xpk_procedure_occurrence PRIMARY KEY NONCLUSTERED ( procedure_occurrence_id ) ;
+
+            ALTER TABLE drug_exposure ADD CONSTRAINT xpk_drug_exposure PRIMARY KEY NONCLUSTERED ( drug_exposure_id ) ;
+
+            ALTER TABLE device_exposure ADD CONSTRAINT xpk_device_exposure PRIMARY KEY NONCLUSTERED ( device_exposure_id ) ;
+
+            ALTER TABLE condition_occurrence ADD CONSTRAINT xpk_condition_occurrence PRIMARY KEY NONCLUSTERED ( condition_occurrence_id ) ;
+
+            ALTER TABLE measurement ADD CONSTRAINT xpk_measurement PRIMARY KEY NONCLUSTERED ( measurement_id ) ;
+
+            ALTER TABLE note ADD CONSTRAINT xpk_note PRIMARY KEY NONCLUSTERED ( note_id ) ;
+
+            ALTER TABLE note_nlp ADD CONSTRAINT xpk_note_nlp PRIMARY KEY NONCLUSTERED ( note_nlp_id ) ;
+
+            ALTER TABLE observation  ADD CONSTRAINT xpk_observation PRIMARY KEY NONCLUSTERED ( observation_id ) ;
+
+
+
+
+            /************************
+            Standardized health system data
+            ************************/
+
+
+            ALTER TABLE location ADD CONSTRAINT xpk_location PRIMARY KEY NONCLUSTERED ( location_id ) ;
+
+            ALTER TABLE care_site ADD CONSTRAINT xpk_care_site PRIMARY KEY NONCLUSTERED ( care_site_id ) ;
+
+            ALTER TABLE provider ADD CONSTRAINT xpk_provider PRIMARY KEY NONCLUSTERED ( provider_id ) ;
+
+
+
+            /************************
+            Standardized health economics
+            ************************/
+
+
+            ALTER TABLE payer_plan_period ADD CONSTRAINT xpk_payer_plan_period PRIMARY KEY NONCLUSTERED ( payer_plan_period_id ) ;
+
+            ALTER TABLE cost ADD CONSTRAINT xpk_visit_cost PRIMARY KEY NONCLUSTERED ( cost_id ) ;
+
+
+            /************************
+            Standardized derived elements
+            ************************/
+
+            ALTER TABLE cohort ADD CONSTRAINT xpk_cohort PRIMARY KEY NONCLUSTERED ( cohort_definition_id, subject_id, cohort_start_date, cohort_end_date  ) ;
+
+            ALTER TABLE cohort_attribute ADD CONSTRAINT xpk_cohort_attribute PRIMARY KEY NONCLUSTERED ( cohort_definition_id, subject_id, cohort_start_date, cohort_end_date, attribute_definition_id ) ;
+
+            ALTER TABLE drug_era ADD CONSTRAINT xpk_drug_era PRIMARY KEY NONCLUSTERED ( drug_era_id ) ;
+
+            ALTER TABLE dose_era  ADD CONSTRAINT xpk_dose_era PRIMARY KEY NONCLUSTERED ( dose_era_id ) ;
+
+            ALTER TABLE condition_era ADD CONSTRAINT xpk_condition_era PRIMARY KEY NONCLUSTERED ( condition_era_id ) ;
+
+
+            /************************
+            *************************
+            *************************
+            *************************
+            Indices
+            *************************
+            *************************
+            *************************
+            ************************/
+
+            /************************
+            Standardized vocabulary
+            ************************/
+
+            CREATE UNIQUE CLUSTERED INDEX idx_concept_concept_id ON concept (concept_id ASC);
+            CREATE INDEX idx_concept_code ON concept (concept_code ASC);
+            CREATE INDEX idx_concept_vocabluary_id ON concept (vocabulary_id ASC);
+            CREATE INDEX idx_concept_domain_id ON concept (domain_id ASC);
+            CREATE INDEX idx_concept_class_id ON concept (concept_class_id ASC);
+
+            CREATE UNIQUE CLUSTERED INDEX idx_vocabulary_vocabulary_id ON vocabulary (vocabulary_id ASC);
+
+            CREATE UNIQUE CLUSTERED INDEX idx_domain_domain_id ON domain (domain_id ASC);
+
+            CREATE UNIQUE CLUSTERED INDEX idx_concept_class_class_id ON concept_class (concept_class_id ASC);
+
+            CREATE INDEX idx_concept_relationship_id_1 ON concept_relationship (concept_id_1 ASC);
+            CREATE INDEX idx_concept_relationship_id_2 ON concept_relationship (concept_id_2 ASC);
+            CREATE INDEX idx_concept_relationship_id_3 ON concept_relationship (relationship_id ASC);
+
+            CREATE UNIQUE CLUSTERED INDEX idx_relationship_rel_id ON relationship (relationship_id ASC);
+
+            CREATE CLUSTERED INDEX idx_concept_synonym_id ON concept_synonym (concept_id ASC);
+
+            CREATE CLUSTERED INDEX idx_concept_ancestor_id_1 ON concept_ancestor (ancestor_concept_id ASC);
+            CREATE INDEX idx_concept_ancestor_id_2 ON concept_ancestor (descendant_concept_id ASC);
+
+            CREATE CLUSTERED INDEX idx_source_to_concept_map_id_3 ON source_to_concept_map (target_concept_id ASC);
+            CREATE INDEX idx_source_to_concept_map_id_1 ON source_to_concept_map (source_vocabulary_id ASC);
+            CREATE INDEX idx_source_to_concept_map_id_2 ON source_to_concept_map (target_vocabulary_id ASC);
+            CREATE INDEX idx_source_to_concept_map_code ON source_to_concept_map (source_code ASC);
+
+            CREATE CLUSTERED INDEX idx_drug_strength_id_1 ON drug_strength (drug_concept_id ASC);
+            CREATE INDEX idx_drug_strength_id_2 ON drug_strength (ingredient_concept_id ASC);
+
+            CREATE CLUSTERED INDEX idx_cohort_definition_id ON cohort_definition (cohort_definition_id ASC);
+
+            CREATE CLUSTERED INDEX idx_attribute_definition_id ON attribute_definition (attribute_definition_id ASC);
+
+
+            /**************************
+            Standardized meta-data
+            ***************************/
+
+
+
+
+
+            /************************
+            Standardized clinical data
+            ************************/
+
+            CREATE UNIQUE CLUSTERED INDEX idx_person_id ON person (person_id ASC);
+
+            CREATE CLUSTERED INDEX idx_observation_period_id ON observation_period (person_id ASC);
+
+            CREATE CLUSTERED INDEX idx_specimen_person_id ON specimen (person_id ASC);
+            CREATE INDEX idx_specimen_concept_id ON specimen (specimen_concept_id ASC);
+
+            CREATE CLUSTERED INDEX idx_death_person_id ON death (person_id ASC);
+
+            CREATE CLUSTERED INDEX idx_visit_person_id ON visit_occurrence (person_id ASC);
+            CREATE INDEX idx_visit_concept_id ON visit_occurrence (visit_concept_id ASC);
+
+            -- CREATE CLUSTERED INDEX idx_visit_detail_person_id ON visit_detail (person_id ASC);
+            -- CREATE INDEX idx_visit_detail_concept_id ON visit_detail (visit_detail_concept_id ASC);
+
+            CREATE CLUSTERED INDEX idx_procedure_person_id ON procedure_occurrence (person_id ASC);
+            CREATE INDEX idx_procedure_concept_id ON procedure_occurrence (procedure_concept_id ASC);
+            CREATE INDEX idx_procedure_visit_id ON procedure_occurrence (visit_occurrence_id ASC);
+
+            CREATE CLUSTERED INDEX idx_drug_person_id ON drug_exposure (person_id ASC);
+            CREATE INDEX idx_drug_concept_id ON drug_exposure (drug_concept_id ASC);
+            CREATE INDEX idx_drug_visit_id ON drug_exposure (visit_occurrence_id ASC);
+
+            CREATE CLUSTERED INDEX idx_device_person_id ON device_exposure (person_id ASC);
+            CREATE INDEX idx_device_concept_id ON device_exposure (device_concept_id ASC);
+            CREATE INDEX idx_device_visit_id ON device_exposure (visit_occurrence_id ASC);
+
+            CREATE CLUSTERED INDEX idx_condition_person_id ON condition_occurrence (person_id ASC);
+            CREATE INDEX idx_condition_concept_id ON condition_occurrence (condition_concept_id ASC);
+            CREATE INDEX idx_condition_visit_id ON condition_occurrence (visit_occurrence_id ASC);
+
+            CREATE CLUSTERED INDEX idx_measurement_person_id ON measurement (person_id ASC);
+            CREATE INDEX idx_measurement_concept_id ON measurement (measurement_concept_id ASC);
+            CREATE INDEX idx_measurement_visit_id ON measurement (visit_occurrence_id ASC);
+
+            CREATE CLUSTERED INDEX idx_note_person_id ON note (person_id ASC);
+            CREATE INDEX idx_note_concept_id ON note (note_type_concept_id ASC);
+            CREATE INDEX idx_note_visit_id ON note (visit_occurrence_id ASC);
+
+            CREATE CLUSTERED INDEX idx_note_nlp_note_id ON note_nlp (note_id ASC);
+            CREATE INDEX idx_note_nlp_concept_id ON note_nlp (note_nlp_concept_id ASC);
+
+            CREATE CLUSTERED INDEX idx_observation_person_id ON observation (person_id ASC);
+            CREATE INDEX idx_observation_concept_id ON observation (observation_concept_id ASC);
+            CREATE INDEX idx_observation_visit_id ON observation (visit_occurrence_id ASC);
+
+            CREATE INDEX idx_fact_relationship_id_1 ON fact_relationship (domain_concept_id_1 ASC);
+            CREATE INDEX idx_fact_relationship_id_2 ON fact_relationship (domain_concept_id_2 ASC);
+            CREATE INDEX idx_fact_relationship_id_3 ON fact_relationship (relationship_concept_id ASC);
+
+
+
+            /************************
+            Standardized health system data
+            ************************/
+
+
+
+
+
+            /************************
+            Standardized health economics
+            ************************/
+
+            CREATE CLUSTERED INDEX idx_period_person_id ON payer_plan_period (person_id ASC);
+
+
+
+
+
+            /************************
+            Standardized derived elements
+            ************************/
+
+
+            CREATE INDEX idx_cohort_subject_id ON cohort (subject_id ASC);
+            CREATE INDEX idx_cohort_c_definition_id ON cohort (cohort_definition_id ASC);
+
+            CREATE INDEX idx_ca_subject_id ON cohort_attribute (subject_id ASC);
+            CREATE INDEX idx_ca_definition_id ON cohort_attribute (cohort_definition_id ASC);
+
+            CREATE CLUSTERED INDEX idx_drug_era_person_id ON drug_era (person_id ASC);
+            CREATE INDEX idx_drug_era_concept_id ON drug_era (drug_concept_id ASC);
+
+            CREATE CLUSTERED INDEX idx_dose_era_person_id ON dose_era (person_id ASC);
+            CREATE INDEX idx_dose_era_concept_id ON dose_era (drug_concept_id ASC);
+
+            CREATE CLUSTERED INDEX idx_condition_era_person_id ON condition_era (person_id ASC);
+            CREATE INDEX idx_condition_era_concept_id ON condition_era (condition_concept_id ASC);
+            -- add foreign key constraints
+
+            /*********************************************************************************
+            # Copyright 2014 Observational Health Data Sciences and Informatics
+            #
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License")
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+            ********************************************************************************/
+
+            /************************
+            ####### #     # ####### ######      #####  ######  #     #           #######      #####      #####
+            #     # ##   ## #     # #     #    #     # #     # ##   ##    #    # #           #     #    #     #  ####  #    #  ####  ##### #####    ##   # #    # #####  ####
+            #     # # # # # #     # #     #    #       #     # # # # #    #    # #                 #    #       #    # ##   # #        #   #    #  #  #  # ##   #   #   #
+            #     # #  #  # #     # ######     #       #     # #  #  #    #    # ######       #####     #       #    # # #  #  ####    #   #    # #    # # # #  #   #    ####
+            #     # #     # #     # #          #       #     # #     #    #    #       # ###       #    #       #    # #  # #      #   #   #####  ###### # #  # #   #        #
+            #     # #     # #     # #          #     # #     # #     #     #  #  #     # ### #     #    #     # #    # #   ## #    #   #   #   #  #    # # #   ##   #   #    #
+            ####### #     # ####### #           #####  ######  #     #      ##    #####  ###  #####      #####   ####  #    #  ####    #   #    # #    # # #    #   #    ####
+            sql server script to create foreign key constraints within OMOP common data model, version 5.3.0
+            last revised: 14-June-2018
+            author:  Patrick Ryan, Clair Blacketer
+            *************************/
+
+
+            /************************
+            *************************
+            *************************
+            *************************
+            Foreign key constraints
+            *************************
+            *************************
+            *************************
+            ************************/
+
+
+            /************************
+            Standardized vocabulary
+            ************************/
+
+
+            ALTER TABLE concept ADD CONSTRAINT fpk_concept_domain FOREIGN KEY (domain_id)  REFERENCES domain (domain_id);
+
+            ALTER TABLE concept ADD CONSTRAINT fpk_concept_class FOREIGN KEY (concept_class_id)  REFERENCES concept_class (concept_class_id);
+
+            ALTER TABLE concept ADD CONSTRAINT fpk_concept_vocabulary FOREIGN KEY (vocabulary_id)  REFERENCES vocabulary (vocabulary_id);
+
+            ALTER TABLE vocabulary ADD CONSTRAINT fpk_vocabulary_concept FOREIGN KEY (vocabulary_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE domain ADD CONSTRAINT fpk_domain_concept FOREIGN KEY (domain_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE concept_class ADD CONSTRAINT fpk_concept_class_concept FOREIGN KEY (concept_class_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE concept_relationship ADD CONSTRAINT fpk_concept_relationship_c_1 FOREIGN KEY (concept_id_1)  REFERENCES concept (concept_id);
+
+            ALTER TABLE concept_relationship ADD CONSTRAINT fpk_concept_relationship_c_2 FOREIGN KEY (concept_id_2)  REFERENCES concept (concept_id);
+
+            ALTER TABLE concept_relationship ADD CONSTRAINT fpk_concept_relationship_id FOREIGN KEY (relationship_id)  REFERENCES relationship (relationship_id);
+
+            ALTER TABLE relationship ADD CONSTRAINT fpk_relationship_concept FOREIGN KEY (relationship_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE relationship ADD CONSTRAINT fpk_relationship_reverse FOREIGN KEY (reverse_relationship_id)  REFERENCES relationship (relationship_id);
+
+            ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_concept FOREIGN KEY (concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_language FOREIGN KEY (language_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE concept_ancestor ADD CONSTRAINT fpk_concept_ancestor_concept_1 FOREIGN KEY (ancestor_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE concept_ancestor ADD CONSTRAINT fpk_concept_ancestor_concept_2 FOREIGN KEY (descendant_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE source_to_concept_map ADD CONSTRAINT fpk_source_to_concept_map_v_1 FOREIGN KEY (source_vocabulary_id)  REFERENCES vocabulary (vocabulary_id);
+
+            ALTER TABLE source_to_concept_map ADD CONSTRAINT fpk_source_concept_id FOREIGN KEY (source_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE source_to_concept_map ADD CONSTRAINT fpk_source_to_concept_map_v_2 FOREIGN KEY (target_vocabulary_id)  REFERENCES vocabulary (vocabulary_id);
+
+            ALTER TABLE source_to_concept_map ADD CONSTRAINT fpk_source_to_concept_map_c_1 FOREIGN KEY (target_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE drug_strength ADD CONSTRAINT fpk_drug_strength_concept_1 FOREIGN KEY (drug_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE drug_strength ADD CONSTRAINT fpk_drug_strength_concept_2 FOREIGN KEY (ingredient_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE drug_strength ADD CONSTRAINT fpk_drug_strength_unit_1 FOREIGN KEY (amount_unit_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE drug_strength ADD CONSTRAINT fpk_drug_strength_unit_2 FOREIGN KEY (numerator_unit_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE drug_strength ADD CONSTRAINT fpk_drug_strength_unit_3 FOREIGN KEY (denominator_unit_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE cohort_definition ADD CONSTRAINT fpk_cohort_definition_concept FOREIGN KEY (definition_type_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE cohort_definition ADD CONSTRAINT fpk_cohort_subject_concept FOREIGN KEY (subject_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE attribute_definition ADD CONSTRAINT fpk_attribute_type_concept FOREIGN KEY (attribute_type_concept_id)  REFERENCES concept (concept_id);
+
+
+            /**************************
+            Standardized meta-data
+            ***************************/
+
+
+
+
+
+            /************************
+            Standardized clinical data
+            ************************/
+
+            -- ALTER TABLE person ADD CONSTRAINT fpk_person_gender_concept FOREIGN KEY (gender_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE person ADD CONSTRAINT fpk_person_race_concept FOREIGN KEY (race_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE person ADD CONSTRAINT fpk_person_ethnicity_concept FOREIGN KEY (ethnicity_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE person ADD CONSTRAINT fpk_person_gender_concept_s FOREIGN KEY (gender_source_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE person ADD CONSTRAINT fpk_person_race_concept_s FOREIGN KEY (race_source_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE person ADD CONSTRAINT fpk_person_ethnicity_concept_s FOREIGN KEY (ethnicity_source_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE person ADD CONSTRAINT fpk_person_location FOREIGN KEY (location_id)  REFERENCES location (location_id);
+
+            ALTER TABLE person ADD CONSTRAINT fpk_person_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            ALTER TABLE person ADD CONSTRAINT fpk_person_care_site FOREIGN KEY (care_site_id)  REFERENCES care_site (care_site_id);
+
+
+            -- TODO: The ALTER TABLE statement conflicted with the FOREIGN KEY constraint "fpk_observation_period_person". The conflict occurred in database "ss-sql", table "dbo.person", column 'person_id'.
+
+            -- ALTER TABLE observation_period ADD CONSTRAINT fpk_observation_period_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE observation_period ADD CONSTRAINT fpk_observation_period_concept FOREIGN KEY (period_type_concept_id)  REFERENCES concept (concept_id);
+
+
+            ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_concept FOREIGN KEY (specimen_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_type_concept FOREIGN KEY (specimen_type_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_unit_concept FOREIGN KEY (unit_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_site_concept FOREIGN KEY (anatomic_site_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_status_concept FOREIGN KEY (disease_status_concept_id)  REFERENCES concept (concept_id);
+
+
+            -- TODO: The ALTER TABLE statement conflicted with the FOREIGN KEY constraint "fpk_death_person". The conflict occurred in database "ss-sql", table "dbo.person", column 'person_id'.
+            -- ALTER TABLE death ADD CONSTRAINT fpk_death_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+            -- TODO: The ALTER TABLE statement conflicted with the FOREIGN KEY constraint "fpk_death_type_concept". The conflict occurred in database "ss-sql", table "dbo.concept", column 'concept_id'.
+            -- ALTER TABLE death ADD CONSTRAINT fpk_death_type_concept FOREIGN KEY (death_type_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE death ADD CONSTRAINT fpk_death_cause_concept FOREIGN KEY (cause_concept_id)  REFERENCES concept (concept_id);
+            -- TODO: The ALTER TABLE statement conflicted with the FOREIGN KEY constraint "fpk_death_cause_concept_s". The conflict occurred in database "ss-sql", table "dbo.concept", column 'concept_id'.
+            -- ALTER TABLE death ADD CONSTRAINT fpk_death_cause_concept_s FOREIGN KEY (cause_source_concept_id)  REFERENCES concept (concept_id);
+
+            -- TODO: The ALTER TABLE statement conflicted with the FOREIGN KEY constraint "fpk_visit_person". The conflict occurred in database "ss-sql", table "dbo.person", column 'person_id'.
+            -- ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+            -- ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_type_concept FOREIGN KEY (visit_type_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+            -- -- TODO
+            -- ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_care_site FOREIGN KEY (care_site_id)  REFERENCES care_site (care_site_id);
+
+            ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_concept_s FOREIGN KEY (visit_source_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_admitting_s FOREIGN KEY (admitting_source_concept_id) REFERENCES concept (concept_id);
+
+            -- ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_discharge FOREIGN KEY (discharge_to_concept_id) REFERENCES concept (concept_id);
+
+            ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_preceding FOREIGN KEY (preceding_visit_occurrence_id) REFERENCES visit_occurrence (visit_occurrence_id);
+
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_type_concept FOREIGN KEY (visit_detail_type_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_care_site FOREIGN KEY (care_site_id)  REFERENCES care_site (care_site_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_concept_s FOREIGN KEY (visit_detail_source_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_admitting_s FOREIGN KEY (admitting_source_concept_id) REFERENCES concept (concept_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_discharge FOREIGN KEY (discharge_to_concept_id) REFERENCES concept (concept_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_preceding FOREIGN KEY (preceding_visit_detail_id) REFERENCES visit_detail (visit_detail_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_parent FOREIGN KEY (visit_detail_parent_id) REFERENCES visit_detail (visit_detail_id);
+
+            -- ALTER TABLE visit_detail ADD CONSTRAINT fpd_v_detail_visit FOREIGN KEY (visit_occurrence_id) REFERENCES visit_occurrence (visit_occurrence_id);
+
+
+            -- ALTER TABLE procedure_occurrence ADD CONSTRAINT fpk_procedure_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE procedure_occurrence ADD CONSTRAINT fpk_procedure_concept FOREIGN KEY (procedure_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE procedure_occurrence ADD CONSTRAINT fpk_procedure_type_concept FOREIGN KEY (procedure_type_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE procedure_occurrence ADD CONSTRAINT fpk_procedure_modifier FOREIGN KEY (modifier_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE procedure_occurrence ADD CONSTRAINT fpk_procedure_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            ALTER TABLE procedure_occurrence ADD CONSTRAINT fpk_procedure_visit FOREIGN KEY (visit_occurrence_id)  REFERENCES visit_occurrence (visit_occurrence_id);
+
+            -- ALTER TABLE procedure_occurrence ADD CONSTRAINT fpk_procedure_concept_s FOREIGN KEY (procedure_source_concept_id)  REFERENCES concept (concept_id);
+
+
+            -- ALTER TABLE drug_exposure ADD CONSTRAINT fpk_drug_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE drug_exposure ADD CONSTRAINT fpk_drug_concept FOREIGN KEY (drug_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE drug_exposure ADD CONSTRAINT fpk_drug_type_concept FOREIGN KEY (drug_type_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE drug_exposure ADD CONSTRAINT fpk_drug_route_concept FOREIGN KEY (route_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE drug_exposure ADD CONSTRAINT fpk_drug_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            ALTER TABLE drug_exposure ADD CONSTRAINT fpk_drug_visit FOREIGN KEY (visit_occurrence_id)  REFERENCES visit_occurrence (visit_occurrence_id);
+
+            -- ALTER TABLE drug_exposure ADD CONSTRAINT fpk_drug_concept_s FOREIGN KEY (drug_source_concept_id)  REFERENCES concept (concept_id);
+
+
+            -- ALTER TABLE device_exposure ADD CONSTRAINT fpk_device_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE device_exposure ADD CONSTRAINT fpk_device_concept FOREIGN KEY (device_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE device_exposure ADD CONSTRAINT fpk_device_type_concept FOREIGN KEY (device_type_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE device_exposure ADD CONSTRAINT fpk_device_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            ALTER TABLE device_exposure ADD CONSTRAINT fpk_device_visit FOREIGN KEY (visit_occurrence_id)  REFERENCES visit_occurrence (visit_occurrence_id);
+
+            -- ALTER TABLE device_exposure ADD CONSTRAINT fpk_device_concept_s FOREIGN KEY (device_source_concept_id)  REFERENCES concept (concept_id);
+
+
+            -- ALTER TABLE condition_occurrence ADD CONSTRAINT fpk_condition_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE condition_occurrence ADD CONSTRAINT fpk_condition_concept FOREIGN KEY (condition_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE condition_occurrence ADD CONSTRAINT fpk_condition_type_concept FOREIGN KEY (condition_type_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE condition_occurrence ADD CONSTRAINT fpk_condition_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            ALTER TABLE condition_occurrence ADD CONSTRAINT fpk_condition_visit FOREIGN KEY (visit_occurrence_id)  REFERENCES visit_occurrence (visit_occurrence_id);
+
+            -- ALTER TABLE condition_occurrence ADD CONSTRAINT fpk_condition_concept_s FOREIGN KEY (condition_source_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE condition_occurrence ADD CONSTRAINT fpk_condition_status_concept FOREIGN KEY (condition_status_concept_id) REFERENCES concept (concept_id);
+
+
+            -- ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_concept FOREIGN KEY (measurement_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_type_concept FOREIGN KEY (measurement_type_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_operator FOREIGN KEY (operator_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_value FOREIGN KEY (value_as_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_unit FOREIGN KEY (unit_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_visit FOREIGN KEY (visit_occurrence_id)  REFERENCES visit_occurrence (visit_occurrence_id);
+
+            -- ALTER TABLE measurement ADD CONSTRAINT fpk_measurement_concept_s FOREIGN KEY (measurement_source_concept_id)  REFERENCES concept (concept_id);
+
+
+            ALTER TABLE note ADD CONSTRAINT fpk_note_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            ALTER TABLE note ADD CONSTRAINT fpk_note_type_concept FOREIGN KEY (note_type_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE note ADD CONSTRAINT fpk_note_class_concept FOREIGN KEY (note_class_concept_id) REFERENCES concept (concept_id);
+
+            ALTER TABLE note ADD CONSTRAINT fpk_note_encoding_concept FOREIGN KEY (encoding_concept_id) REFERENCES concept (concept_id);
+
+            ALTER TABLE note ADD CONSTRAINT fpk_language_concept FOREIGN KEY (language_concept_id) REFERENCES concept (concept_id);
+
+            ALTER TABLE note ADD CONSTRAINT fpk_note_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            ALTER TABLE note ADD CONSTRAINT fpk_note_visit FOREIGN KEY (visit_occurrence_id)  REFERENCES visit_occurrence (visit_occurrence_id);
+
+
+            ALTER TABLE note_nlp ADD CONSTRAINT fpk_note_nlp_note FOREIGN KEY (note_id) REFERENCES note (note_id);
+
+            ALTER TABLE note_nlp ADD CONSTRAINT fpk_note_nlp_section_concept FOREIGN KEY (section_concept_id) REFERENCES concept (concept_id);
+
+            ALTER TABLE note_nlp ADD CONSTRAINT fpk_note_nlp_concept FOREIGN KEY (note_nlp_concept_id) REFERENCES concept (concept_id);
+
+
+
+            -- ALTER TABLE observation ADD CONSTRAINT fpk_observation_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE observation ADD CONSTRAINT fpk_observation_concept FOREIGN KEY (observation_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE observation ADD CONSTRAINT fpk_observation_type_concept FOREIGN KEY (observation_type_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE observation ADD CONSTRAINT fpk_observation_value FOREIGN KEY (value_as_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE observation ADD CONSTRAINT fpk_observation_qualifier FOREIGN KEY (qualifier_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE observation ADD CONSTRAINT fpk_observation_unit FOREIGN KEY (unit_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE observation ADD CONSTRAINT fpk_observation_provider FOREIGN KEY (provider_id)  REFERENCES provider (provider_id);
+
+            ALTER TABLE observation ADD CONSTRAINT fpk_observation_visit FOREIGN KEY (visit_occurrence_id)  REFERENCES visit_occurrence (visit_occurrence_id);
+
+            -- ALTER TABLE observation ADD CONSTRAINT fpk_observation_concept_s FOREIGN KEY (observation_source_concept_id)  REFERENCES concept (concept_id);
+
+
+            ALTER TABLE fact_relationship ADD CONSTRAINT fpk_fact_domain_1 FOREIGN KEY (domain_concept_id_1)  REFERENCES concept (concept_id);
+
+            ALTER TABLE fact_relationship ADD CONSTRAINT fpk_fact_domain_2 FOREIGN KEY (domain_concept_id_2)  REFERENCES concept (concept_id);
+
+            ALTER TABLE fact_relationship ADD CONSTRAINT fpk_fact_relationship FOREIGN KEY (relationship_concept_id)  REFERENCES concept (concept_id);
+
+
+
+            /************************
+            Standardized health system data
+            ************************/
+
+            ALTER TABLE care_site ADD CONSTRAINT fpk_care_site_location FOREIGN KEY (location_id)  REFERENCES location (location_id);
+
+            -- ALTER TABLE care_site ADD CONSTRAINT fpk_care_site_place FOREIGN KEY (place_of_service_concept_id)  REFERENCES concept (concept_id);
+
+
+            -- ALTER TABLE provider ADD CONSTRAINT fpk_provider_specialty FOREIGN KEY (specialty_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE provider ADD CONSTRAINT fpk_provider_care_site FOREIGN KEY (care_site_id)  REFERENCES care_site (care_site_id);
+
+            -- ALTER TABLE provider ADD CONSTRAINT fpk_provider_gender FOREIGN KEY (gender_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE provider ADD CONSTRAINT fpk_provider_specialty_s FOREIGN KEY (specialty_source_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE provider ADD CONSTRAINT fpk_provider_gender_s FOREIGN KEY (gender_source_concept_id)  REFERENCES concept (concept_id);
+
+
+
+
+            /************************
+            Standardized health economics
+            ************************/
+
+            -- ALTER TABLE payer_plan_period ADD CONSTRAINT fpk_payer_plan_period FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE cost ADD CONSTRAINT fpk_visit_cost_currency FOREIGN KEY (currency_concept_id)  REFERENCES concept (concept_id);
+
+            -- ALTER TABLE cost ADD CONSTRAINT fpk_visit_cost_period FOREIGN KEY (payer_plan_period_id)  REFERENCES payer_plan_period (payer_plan_period_id);
+
+            -- ALTER TABLE cost ADD CONSTRAINT fpk_drg_concept FOREIGN KEY (drg_concept_id) REFERENCES concept (concept_id);
+
+            /************************
+            Standardized derived elements
+            ************************/
+
+
+            --ALTER TABLE cohort ADD CONSTRAINT fpk_cohort_definition FOREIGN KEY (cohort_definition_id)  REFERENCES cohort_definition (cohort_definition_id);
+
+
+            ALTER TABLE cohort_attribute ADD CONSTRAINT fpk_ca_cohort_definition FOREIGN KEY (cohort_definition_id)  REFERENCES cohort_definition (cohort_definition_id);
+
+            ALTER TABLE cohort_attribute ADD CONSTRAINT fpk_ca_attribute_definition FOREIGN KEY (attribute_definition_id)  REFERENCES attribute_definition (attribute_definition_id);
+
+            ALTER TABLE cohort_attribute ADD CONSTRAINT fpk_ca_value FOREIGN KEY (value_as_concept_id)  REFERENCES concept (concept_id);
+
+
+            -- ALTER TABLE drug_era ADD CONSTRAINT fpk_drug_era_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE drug_era ADD CONSTRAINT fpk_drug_era_concept FOREIGN KEY (drug_concept_id)  REFERENCES concept (concept_id);
+
+
+            ALTER TABLE dose_era ADD CONSTRAINT fpk_dose_era_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            ALTER TABLE dose_era ADD CONSTRAINT fpk_dose_era_concept FOREIGN KEY (drug_concept_id)  REFERENCES concept (concept_id);
+
+            ALTER TABLE dose_era ADD CONSTRAINT fpk_dose_era_unit_concept FOREIGN KEY (unit_concept_id)  REFERENCES concept (concept_id);
+
+
+            -- ALTER TABLE condition_era ADD CONSTRAINT fpk_condition_era_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+
+            -- ALTER TABLE condition_era ADD CONSTRAINT fpk_condition_era_concept FOREIGN KEY (condition_concept_id)  REFERENCES concept (concept_id);
+
+
+            /************************
+            *************************
+            *************************
+            *************************
+            Unique constraints
+            *************************
+            *************************
+            *************************
+            ************************/
+
+            ALTER TABLE concept_synonym ADD CONSTRAINT uq_concept_synonym UNIQUE (concept_id, concept_synonym_name, language_concept_id);
+            -- @TranCount = 0 means no transaction was  
+            -- started before the procedure was called.  
+            -- The procedure must commit the transaction  
+            -- it started.  
+            SET @PrintMsg =  CAST(@@TRANCOUNT as varchar(MAX))  + ' No errors ' +  CAST(@TranCount as varchar(MAX));
+            PRINT(@PrintMsg)
+            IF @TranCount = 0
+                COMMIT TRANSACTION;
+    END TRY 
+    BEGIN CATCH 
+        -- An error occurred; must determine  
+        -- which type of rollback will roll  
+        -- back only the work done in the  
+        -- procedure. 
+        DECLARE @PrintMsgs VARCHAR(MAX);
+        SET @PrintMsgs =   CAST(@@TRANCOUNT as varchar(MAX)) + ' In Catch ' +  CAST(@TranCount as varchar(MAX))
+        PRINT(@PrintMsgs)
+        PRINT(ERROR_MESSAGE())
+        
+        IF @TranCount = 0  
+            -- Transaction started in procedure.  
+            -- Roll back complete transaction.  
+            ROLLBACK TRANSACTION;
+        ELSE
+            -- Transaction started before procedure  
+            -- called, do not roll back modifications  
+            -- made before the procedure was called.  
+            IF XACT_STATE() <> -1  
+                -- If the transaction is still valid, just  
+                -- roll back to the savepoint set at the  
+                -- start of the stored procedure.  
+                ROLLBACK TRANSACTION add_indexes_constraints;  
+                -- If the transaction is uncommitable, a  
+                -- rollback to the savepoint is not allowed  
+                -- because the savepoint rollback writes to  
+                -- the log. Just return to the caller, which  
+                -- should roll back the outer transaction. 
+
+		-- After the appropriate rollback, echo error information to the caller. 
+        THROW;
+    END CATCH
+    DECLARE @PrintMsgss VARCHAR(MAX);
+    SET @PrintMsgss =   CAST(@@TRANCOUNT as varchar(MAX)) + 'Outside Catch '
+    PRINT(@PrintMsgss)
+END
+

--- a/sql/SPROC_move_data_to_permanent_tables.sql
+++ b/sql/SPROC_move_data_to_permanent_tables.sql
@@ -1,0 +1,57 @@
+-- TODO: Output results, Clean up cursor 
+CREATE PROCEDURE move_data_to_permanent_tables
+AS
+    BEGIN TRY
+        BEGIN TRANSACTION move_data_to_permanent_tables
+        EXEC dbo.remove_indexes_constraints;
+        DECLARE @current_table_name VARCHAR(MAX);
+        DECLARE @staging_table_name VARCHAR(MAX);
+        SET @current_table_name = ''
+
+        DECLARE omop_tables_cursor CURSOR FOR 
+        SELECT table_name 
+        FROM watermark_copy_staging_tables
+
+        -- https://www.mssqltips.com/sqlservertip/1599/cursor-in-sql-server/
+        OPEN omop_tables_cursor
+        FETCH NEXT FROM omop_tables_cursor INTO @current_table_name
+
+        WHILE @@FETCH_STATUS = 0
+
+        BEGIN  
+        DECLARE @truncate_sql VARCHAR(MAX)
+        DECLARE @switch_sql VARCHAR(MAX)
+        SET @truncate_sql = 'TRUNCATE TABLE ' + @current_table_name
+        SET @staging_table_name = 'staging_' + @current_table_name
+        SET @switch_sql = 'ALTER TABLE ' + @staging_table_name + ' SWITCH TO ' + @current_table_name
+        EXEC (@truncate_sql)
+        EXEC (@switch_sql)
+        FETCH NEXT FROM omop_tables_cursor INTO @current_table_name;
+        END 
+        CLOSE omop_tables_cursor;  
+        DEALLOCATE omop_tables_cursor; 
+
+        EXEC dbo.add_indexes_constraints;
+        TRUNCATE TABLE table_names;
+        COMMIT TRANSACTION move_data_to_permanent_tables;
+        RETURN 1; 
+    END TRY
+    BEGIN CATCH
+
+        IF (SELECT CURSOR_STATUS('global','omop_tables_cursor')) >= -1
+        BEGIN
+        DEALLOCATE omop_tables_cursor;
+        END
+
+        -- Transaction uncommittable
+        IF (XACT_STATE()) = -1
+        ROLLBACK TRANSACTION move_data_to_permanent_tables;
+    
+        -- Transaction committable
+        IF (XACT_STATE()) = 1
+        COMMIT TRANSACTION move_data_to_permanent_tables;
+
+        THROW;
+
+    END CATCH;
+

--- a/sql/SPROC_remove_indexes_constraints.sql
+++ b/sql/SPROC_remove_indexes_constraints.sql
@@ -1,0 +1,716 @@
+CREATE PROCEDURE remove_indexes_constraints
+AS
+BEGIN
+        -- add foreign key constraints
+
+        /*********************************************************************************
+        # Copyright 2014 Observational Health Data Sciences and Informatics
+        #
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License")
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+        ********************************************************************************/
+
+        /************************
+        ####### #     # ####### ######      #####  ######  #     #           #######      #####      #####
+        #     # ##   ## #     # #     #    #     # #     # ##   ##    #    # #           #     #    #     #  ####  #    #  ####  ##### #####    ##   # #    # #####  ####
+        #     # # # # # #     # #     #    #       #     # # # # #    #    # #                 #    #       #    # ##   # #        #   #    #  #  #  # ##   #   #   #
+        #     # #  #  # #     # ######     #       #     # #  #  #    #    # ######       #####     #       #    # # #  #  ####    #   #    # #    # # # #  #   #    ####
+        #     # #     # #     # #          #       #     # #     #    #    #       # ###       #    #       #    # #  # #      #   #   #####  ###### # #  # #   #        #
+        #     # #     # #     # #          #     # #     # #     #     #  #  #     # ### #     #    #     # #    # #   ## #    #   #   #   #  #    # # #   ##   #   #    #
+        ####### #     # ####### #           #####  ######  #     #      ##    #####  ###  #####      #####   ####  #    #  ####    #   #    # #    # # #    #   #    ####
+        sql server script to create foreign key constraints within OMOP common data model, version 5.3.0
+        last revised: 14-June-2018
+        author:  Patrick Ryan, Clair Blacketer
+        *************************/
+
+
+        /************************
+        *************************
+        *************************
+        *************************
+        Foreign key constraints
+        *************************
+        *************************
+        *************************
+        ************************/
+
+
+        /************************
+        Standardized vocabulary
+        ************************/
+
+
+        ALTER TABLE concept DROP CONSTRAINT fpk_concept_domain;
+
+        ALTER TABLE concept DROP CONSTRAINT fpk_concept_class;
+
+        ALTER TABLE concept DROP CONSTRAINT fpk_concept_vocabulary;
+
+        ALTER TABLE vocabulary DROP CONSTRAINT fpk_vocabulary_concept;
+
+        ALTER TABLE domain DROP CONSTRAINT fpk_domain_concept;
+
+        ALTER TABLE concept_class DROP CONSTRAINT fpk_concept_class_concept;
+
+        ALTER TABLE concept_relationship DROP CONSTRAINT fpk_concept_relationship_c_1;
+
+        ALTER TABLE concept_relationship DROP CONSTRAINT fpk_concept_relationship_c_2;
+
+        ALTER TABLE concept_relationship DROP CONSTRAINT fpk_concept_relationship_id;
+
+        ALTER TABLE relationship DROP CONSTRAINT fpk_relationship_concept;
+
+        ALTER TABLE relationship DROP CONSTRAINT fpk_relationship_reverse;
+
+        ALTER TABLE concept_synonym DROP CONSTRAINT fpk_concept_synonym_concept;
+
+        ALTER TABLE concept_synonym DROP CONSTRAINT fpk_concept_synonym_language;
+
+        ALTER TABLE concept_ancestor DROP CONSTRAINT fpk_concept_ancestor_concept_1;
+
+        ALTER TABLE concept_ancestor DROP CONSTRAINT fpk_concept_ancestor_concept_2;
+
+        ALTER TABLE source_to_concept_map DROP CONSTRAINT fpk_source_to_concept_map_v_1;
+
+        ALTER TABLE source_to_concept_map DROP CONSTRAINT fpk_source_concept_id;
+
+        ALTER TABLE source_to_concept_map DROP CONSTRAINT fpk_source_to_concept_map_v_2;
+
+        ALTER TABLE source_to_concept_map DROP CONSTRAINT fpk_source_to_concept_map_c_1;
+
+        ALTER TABLE drug_strength DROP CONSTRAINT fpk_drug_strength_concept_1;
+
+        ALTER TABLE drug_strength DROP CONSTRAINT fpk_drug_strength_concept_2;
+
+        ALTER TABLE drug_strength DROP CONSTRAINT fpk_drug_strength_unit_1;
+
+        ALTER TABLE drug_strength DROP CONSTRAINT fpk_drug_strength_unit_2;
+
+        ALTER TABLE drug_strength DROP CONSTRAINT fpk_drug_strength_unit_3;
+
+        ALTER TABLE cohort_definition DROP CONSTRAINT fpk_cohort_definition_concept;
+
+        ALTER TABLE cohort_definition DROP CONSTRAINT fpk_cohort_subject_concept;
+
+        ALTER TABLE attribute_definition DROP CONSTRAINT fpk_attribute_type_concept;
+
+
+        /**************************
+        Standardized meta-data
+        ***************************/
+
+
+
+
+
+        /************************
+        Standardized clinical data
+        ************************/
+
+        -- ALTER TABLE person DROP CONSTRAINT fpk_person_gender_concept;
+
+        -- ALTER TABLE person DROP CONSTRAINT fpk_person_race_concept;
+
+        -- ALTER TABLE person DROP CONSTRAINT fpk_person_ethnicity_concept;
+
+        -- ALTER TABLE person DROP CONSTRAINT fpk_person_gender_concept_s;
+
+        -- ALTER TABLE person DROP CONSTRAINT fpk_person_race_concept_s;
+
+        -- ALTER TABLE person DROP CONSTRAINT fpk_person_ethnicity_concept_s;
+
+        ALTER TABLE person DROP CONSTRAINT fpk_person_location;
+
+        ALTER TABLE person DROP CONSTRAINT fpk_person_provider;
+
+        ALTER TABLE person DROP CONSTRAINT fpk_person_care_site;
+
+        -- TODO: The ALTER TABLE statement conflicted with the FOREIGN KEY constraint "fpk_observation_period_person". The conflict occurred in database "ss-sql", table "dbo.person", column 'person_id'.
+        -- ALTER TABLE observation_period DROP CONSTRAINT fpk_observation_period_person;
+
+        -- ALTER TABLE observation_period DROP CONSTRAINT fpk_observation_period_concept;
+
+
+        ALTER TABLE specimen DROP CONSTRAINT fpk_specimen_person;
+
+        ALTER TABLE specimen DROP CONSTRAINT fpk_specimen_concept;
+
+        ALTER TABLE specimen DROP CONSTRAINT fpk_specimen_type_concept;
+
+        ALTER TABLE specimen DROP CONSTRAINT fpk_specimen_unit_concept;
+
+        ALTER TABLE specimen DROP CONSTRAINT fpk_specimen_site_concept;
+
+        ALTER TABLE specimen DROP CONSTRAINT fpk_specimen_status_concept;
+
+        -- TODO: The ALTER TABLE statement conflicted with the FOREIGN KEY constraint "fpk_death_person". The conflict occurred in database "ss-sql", table "dbo.person", column 'person_id'.
+        -- ALTER TABLE death DROP CONSTRAINT fpk_death_person;
+        -- TODO: The ALTER TABLE statement conflicted with the FOREIGN KEY constraint "fpk_death_type_concept". The conflict occurred in database "ss-sql", table "dbo.concept", column 'concept_id'.
+        -- ALTER TABLE death DROP CONSTRAINT fpk_death_type_concept;
+
+        ALTER TABLE death DROP CONSTRAINT fpk_death_cause_concept;
+
+        -- ALTER TABLE death DROP CONSTRAINT fpk_death_cause_concept_s;
+
+        -- ALTER TABLE visit_occurrence DROP CONSTRAINT fpk_visit_person;
+
+        -- ALTER TABLE visit_occurrence DROP CONSTRAINT fpk_visit_type_concept;
+
+        -- ALTER TABLE visit_occurrence DROP CONSTRAINT fpk_visit_provider;
+
+        -- ALTER TABLE visit_occurrence DROP CONSTRAINT fpk_visit_care_site;
+
+        ALTER TABLE visit_occurrence DROP CONSTRAINT fpk_visit_concept_s;
+
+        -- ALTER TABLE visit_occurrence DROP CONSTRAINT fpk_visit_admitting_s;
+
+        -- ALTER TABLE visit_occurrence DROP CONSTRAINT fpk_visit_discharge;
+
+        ALTER TABLE visit_occurrence DROP CONSTRAINT fpk_visit_preceding;
+
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_person;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_type_concept;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_provider;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_care_site;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_concept_s;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_admitting_s;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_discharge;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_preceding;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpk_v_detail_parent;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT fpd_v_detail_visit;
+
+
+        -- ALTER TABLE procedure_occurrence DROP CONSTRAINT fpk_procedure_person;
+
+        -- ALTER TABLE procedure_occurrence DROP CONSTRAINT fpk_procedure_concept;
+
+        -- ALTER TABLE procedure_occurrence DROP CONSTRAINT fpk_procedure_type_concept;
+
+        ALTER TABLE procedure_occurrence DROP CONSTRAINT fpk_procedure_modifier;
+
+        -- ALTER TABLE procedure_occurrence DROP CONSTRAINT fpk_procedure_provider;
+
+        ALTER TABLE procedure_occurrence DROP CONSTRAINT fpk_procedure_visit;
+
+        -- ALTER TABLE procedure_occurrence DROP CONSTRAINT fpk_procedure_concept_s;
+
+
+        -- ALTER TABLE drug_exposure DROP CONSTRAINT fpk_drug_person;
+
+        -- ALTER TABLE drug_exposure DROP CONSTRAINT fpk_drug_concept;
+
+        -- ALTER TABLE drug_exposure DROP CONSTRAINT fpk_drug_type_concept;
+
+        ALTER TABLE drug_exposure DROP CONSTRAINT fpk_drug_route_concept;
+
+        -- ALTER TABLE drug_exposure DROP CONSTRAINT fpk_drug_provider;
+
+        ALTER TABLE drug_exposure DROP CONSTRAINT fpk_drug_visit;
+
+        -- ALTER TABLE drug_exposure DROP CONSTRAINT fpk_drug_concept_s;
+
+
+        -- ALTER TABLE device_exposure DROP CONSTRAINT fpk_device_person;
+
+        -- ALTER TABLE device_exposure DROP CONSTRAINT fpk_device_concept;
+
+        -- ALTER TABLE device_exposure DROP CONSTRAINT fpk_device_type_concept;
+
+        -- ALTER TABLE device_exposure DROP CONSTRAINT fpk_device_provider;
+
+        ALTER TABLE device_exposure DROP CONSTRAINT fpk_device_visit;
+
+        -- ALTER TABLE device_exposure DROP CONSTRAINT fpk_device_concept_s;
+
+
+        -- ALTER TABLE condition_occurrence DROP CONSTRAINT fpk_condition_person;
+
+        -- ALTER TABLE condition_occurrence DROP CONSTRAINT fpk_condition_concept;
+
+        -- ALTER TABLE condition_occurrence DROP CONSTRAINT fpk_condition_type_concept;
+
+        -- ALTER TABLE condition_occurrence DROP CONSTRAINT fpk_condition_provider;
+
+        ALTER TABLE condition_occurrence DROP CONSTRAINT fpk_condition_visit;
+
+        -- ALTER TABLE condition_occurrence DROP CONSTRAINT fpk_condition_concept_s;
+
+        -- ALTER TABLE condition_occurrence DROP CONSTRAINT fpk_condition_status_concept;
+
+
+        -- ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_person;
+
+        -- ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_concept;
+
+        -- ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_type_concept;
+
+        ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_operator;
+
+        -- ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_value;
+
+        ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_unit;
+
+        -- ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_provider;
+
+        ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_visit;
+
+        -- ALTER TABLE measurement DROP CONSTRAINT fpk_measurement_concept_s;
+
+
+        ALTER TABLE note DROP CONSTRAINT fpk_note_person;
+
+        ALTER TABLE note DROP CONSTRAINT fpk_note_type_concept;
+
+        ALTER TABLE note DROP CONSTRAINT fpk_note_class_concept;
+
+        ALTER TABLE note DROP CONSTRAINT fpk_note_encoding_concept;
+
+        ALTER TABLE note DROP CONSTRAINT fpk_language_concept;
+
+        ALTER TABLE note DROP CONSTRAINT fpk_note_provider;
+
+        ALTER TABLE note DROP CONSTRAINT fpk_note_visit;
+
+
+        ALTER TABLE note_nlp DROP CONSTRAINT fpk_note_nlp_note;
+
+        ALTER TABLE note_nlp DROP CONSTRAINT fpk_note_nlp_section_concept;
+
+        ALTER TABLE note_nlp DROP CONSTRAINT fpk_note_nlp_concept;
+
+
+
+        -- ALTER TABLE observation DROP CONSTRAINT fpk_observation_person;
+
+        -- ALTER TABLE observation DROP CONSTRAINT fpk_observation_concept;
+
+        -- ALTER TABLE observation DROP CONSTRAINT fpk_observation_type_concept;
+
+        -- ALTER TABLE observation DROP CONSTRAINT fpk_observation_value;
+
+        ALTER TABLE observation DROP CONSTRAINT fpk_observation_qualifier;
+
+        ALTER TABLE observation DROP CONSTRAINT fpk_observation_unit;
+
+        -- ALTER TABLE observation DROP CONSTRAINT fpk_observation_provider;
+
+        ALTER TABLE observation DROP CONSTRAINT fpk_observation_visit;
+
+        -- ALTER TABLE observation DROP CONSTRAINT fpk_observation_concept_s;
+
+
+        ALTER TABLE fact_relationship DROP CONSTRAINT fpk_fact_domain_1;
+
+        ALTER TABLE fact_relationship DROP CONSTRAINT fpk_fact_domain_2;
+
+        ALTER TABLE fact_relationship DROP CONSTRAINT fpk_fact_relationship;
+
+
+
+        /************************
+        Standardized health system data
+        ************************/
+
+        ALTER TABLE care_site DROP CONSTRAINT fpk_care_site_location;
+
+        -- ALTER TABLE care_site DROP CONSTRAINT fpk_care_site_place;
+
+
+        -- ALTER TABLE provider DROP CONSTRAINT fpk_provider_specialty;
+
+        -- ALTER TABLE provider DROP CONSTRAINT fpk_provider_care_site;
+
+        -- ALTER TABLE provider DROP CONSTRAINT fpk_provider_gender;
+
+        -- ALTER TABLE provider DROP CONSTRAINT fpk_provider_specialty_s;
+
+        -- ALTER TABLE provider DROP CONSTRAINT fpk_provider_gender_s;
+
+
+
+
+        /************************
+        Standardized health economics
+        ************************/
+
+        -- ALTER TABLE payer_plan_period DROP CONSTRAINT fpk_payer_plan_period;
+
+        -- ALTER TABLE cost DROP CONSTRAINT fpk_visit_cost_currency;
+
+        -- ALTER TABLE cost DROP CONSTRAINT fpk_visit_cost_period;
+
+        -- ALTER TABLE cost DROP CONSTRAINT fpk_drg_concept;
+
+        /************************
+        Standardized derived elements
+        ************************/
+
+
+        --ALTER TABLE cohort DROP CONSTRAINT fpk_cohort_definition;
+
+
+        ALTER TABLE cohort_attribute DROP CONSTRAINT fpk_ca_cohort_definition;
+
+        ALTER TABLE cohort_attribute DROP CONSTRAINT fpk_ca_attribute_definition;
+
+        ALTER TABLE cohort_attribute DROP CONSTRAINT fpk_ca_value;
+
+
+        -- ALTER TABLE drug_era DROP CONSTRAINT fpk_drug_era_person;
+
+        -- ALTER TABLE drug_era DROP CONSTRAINT fpk_drug_era_concept;
+
+
+        ALTER TABLE dose_era DROP CONSTRAINT fpk_dose_era_person;
+
+        ALTER TABLE dose_era DROP CONSTRAINT fpk_dose_era_concept;
+
+        ALTER TABLE dose_era DROP CONSTRAINT fpk_dose_era_unit_concept;
+
+
+        -- ALTER TABLE condition_era DROP CONSTRAINT fpk_condition_era_person;
+
+        -- ALTER TABLE condition_era DROP CONSTRAINT fpk_condition_era_concept;
+
+
+        /************************
+        *************************
+        *************************
+        *************************
+        Unique constraints
+        *************************
+        *************************
+        *************************
+        ************************/
+
+        ALTER TABLE concept_synonym DROP CONSTRAINT uq_concept_synonym;
+
+        -- add indices and primary keys
+        /*********************************************************************************
+        # Copyright 2014 Observational Health Data Sciences and Informatics
+        #
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+        ********************************************************************************/
+
+        /************************
+        ####### #     # ####### ######      #####  ######  #     #           #######      #####     ###
+        #     # ##   ## #     # #     #    #     # #     # ##   ##    #    # #           #     #     #  #    # #####  ###### #    # ######  ####
+        #     # # # # # #     # #     #    #       #     # # # # #    #    # #                 #     #  ##   # #    # #       #  #  #      #
+        #     # #  #  # #     # ######     #       #     # #  #  #    #    # ######       #####      #  # #  # #    # #####    ##   #####   ####
+        #     # #     # #     # #          #       #     # #     #    #    #       # ###       #     #  #  # # #    # #        ##   #           #
+        #     # #     # #     # #          #     # #     # #     #     #  #  #     # ### #     #     #  #   ## #    # #       #  #  #      #    #
+        ####### #     # ####### #           #####  ######  #     #      ##    #####  ###  #####     ### #    # #####  ###### #    # ######  ####
+        sql server script to create the required indexes within OMOP common data model, version 5.3
+        last revised: 14-November-2017
+        author:  Patrick Ryan, Clair Blacketer
+        description:  These primary keys and indices are considered a minimal requirement to ensure adequate performance of analyses.
+        *************************/
+
+
+        /************************
+        *************************
+        *************************
+        *************************
+        Primary key constraints
+        *************************
+        *************************
+        *************************
+        ************************/
+
+
+
+        /************************
+        Standardized vocabulary
+        ************************/
+
+
+
+        ALTER TABLE concept DROP CONSTRAINT xpk_concept;
+
+        ALTER TABLE vocabulary DROP CONSTRAINT xpk_vocabulary;
+
+-- Msg 3725, Level 16, State 0, Line 1 The constraint 'xpk_domain' is being referenced by table 'concept', foreign key constraint 'fpk_concept_domain'.
+        ALTER TABLE domain DROP CONSTRAINT xpk_domain;
+
+        ALTER TABLE concept_class DROP CONSTRAINT xpk_concept_class;
+
+        ALTER TABLE concept_relationship DROP CONSTRAINT xpk_concept_relationship;
+
+        ALTER TABLE relationship DROP CONSTRAINT xpk_relationship;
+
+        ALTER TABLE concept_ancestor DROP CONSTRAINT xpk_concept_ancestor;
+
+        ALTER TABLE source_to_concept_map DROP CONSTRAINT xpk_source_to_concept_map;
+
+        ALTER TABLE drug_strength DROP CONSTRAINT xpk_drug_strength;
+
+        ALTER TABLE cohort_definition DROP CONSTRAINT xpk_cohort_definition;
+
+        ALTER TABLE attribute_definition DROP CONSTRAINT xpk_attribute_definition;
+
+
+        /**************************
+        Standardized meta-data
+        ***************************/
+
+
+
+        /************************
+        Standardized clinical data
+        ************************/
+
+
+        /**PRIMARY KEY NONCLUSTERED constraints**/
+
+        ALTER TABLE person DROP CONSTRAINT xpk_person;
+
+        ALTER TABLE observation_period DROP CONSTRAINT xpk_observation_period;
+
+        ALTER TABLE specimen DROP CONSTRAINT xpk_specimen;
+
+        ALTER TABLE death DROP CONSTRAINT xpk_death;
+
+        ALTER TABLE visit_occurrence DROP CONSTRAINT xpk_visit_occurrence;
+
+        -- ALTER TABLE visit_detail DROP CONSTRAINT xpk_visit_detail;
+
+        ALTER TABLE procedure_occurrence DROP CONSTRAINT xpk_procedure_occurrence;
+
+        ALTER TABLE drug_exposure DROP CONSTRAINT xpk_drug_exposure;
+
+        ALTER TABLE device_exposure DROP CONSTRAINT xpk_device_exposure;
+
+        ALTER TABLE condition_occurrence DROP CONSTRAINT xpk_condition_occurrence;
+
+        ALTER TABLE measurement DROP CONSTRAINT xpk_measurement;
+
+        ALTER TABLE note DROP CONSTRAINT xpk_note;
+
+        ALTER TABLE note_nlp DROP CONSTRAINT xpk_note_nlp;
+
+        ALTER TABLE observation  DROP CONSTRAINT xpk_observation;
+
+
+
+
+        /************************
+        Standardized health system data
+        ************************/
+
+
+        ALTER TABLE location DROP CONSTRAINT xpk_location;
+
+        ALTER TABLE care_site DROP CONSTRAINT xpk_care_site;
+
+        ALTER TABLE provider DROP CONSTRAINT xpk_provider;
+
+
+
+        /************************
+        Standardized health economics
+        ************************/
+
+
+        ALTER TABLE payer_plan_period DROP CONSTRAINT xpk_payer_plan_period;
+
+        ALTER TABLE cost DROP CONSTRAINT xpk_visit_cost;
+
+
+        /************************
+        Standardized derived elements
+        ************************/
+
+        ALTER TABLE cohort DROP CONSTRAINT xpk_cohort;
+
+        ALTER TABLE cohort_attribute DROP CONSTRAINT xpk_cohort_attribute;
+
+        ALTER TABLE drug_era DROP CONSTRAINT xpk_drug_era;
+
+        ALTER TABLE dose_era  DROP CONSTRAINT xpk_dose_era;
+
+        ALTER TABLE condition_era DROP CONSTRAINT xpk_condition_era;
+
+
+        /************************
+        *************************
+        *************************
+        *************************
+        Indices
+        *************************
+        *************************
+        *************************
+        ************************/
+
+        /************************
+        Standardized vocabulary
+        ************************/
+
+        DROP INDEX idx_concept_concept_id ON concept;
+        DROP INDEX  idx_concept_code ON concept;
+        DROP INDEX  idx_concept_vocabluary_id ON concept;
+        DROP INDEX  idx_concept_domain_id ON concept;
+        DROP INDEX  idx_concept_class_id ON concept;
+
+        DROP INDEX idx_vocabulary_vocabulary_id ON vocabulary;
+
+        DROP INDEX idx_domain_domain_id ON domain;
+
+        DROP INDEX idx_concept_class_class_id ON concept_class;
+
+        DROP INDEX  idx_concept_relationship_id_1 ON concept_relationship;
+        DROP INDEX  idx_concept_relationship_id_2 ON concept_relationship;
+        DROP INDEX  idx_concept_relationship_id_3 ON concept_relationship;
+
+        DROP INDEX idx_relationship_rel_id ON relationship;
+
+        DROP INDEX  idx_concept_synonym_id ON concept_synonym;
+
+        DROP INDEX  idx_concept_ancestor_id_1 ON concept_ancestor;
+        DROP INDEX  idx_concept_ancestor_id_2 ON concept_ancestor;
+
+        DROP INDEX  idx_source_to_concept_map_id_3 ON source_to_concept_map;
+        DROP INDEX  idx_source_to_concept_map_id_1 ON source_to_concept_map;
+        DROP INDEX  idx_source_to_concept_map_id_2 ON source_to_concept_map;
+        DROP INDEX  idx_source_to_concept_map_code ON source_to_concept_map;
+
+        DROP INDEX  idx_drug_strength_id_1 ON drug_strength;
+        DROP INDEX  idx_drug_strength_id_2 ON drug_strength;
+
+        DROP INDEX  idx_cohort_definition_id ON cohort_definition;
+
+        DROP INDEX  idx_attribute_definition_id ON attribute_definition;
+
+
+        /**************************
+        Standardized meta-data
+        ***************************/
+
+
+
+
+
+        /************************
+        Standardized clinical data
+        ************************/
+
+        DROP INDEX idx_person_id ON person;
+
+        DROP INDEX  idx_observation_period_id ON observation_period;
+
+        DROP INDEX  idx_specimen_person_id ON specimen;
+        DROP INDEX  idx_specimen_concept_id ON specimen;
+
+        DROP INDEX  idx_death_person_id ON death;
+
+        DROP INDEX  idx_visit_person_id ON visit_occurrence;
+        DROP INDEX  idx_visit_concept_id ON visit_occurrence;
+
+        -- DROP INDEX  idx_visit_detail_person_id ON visit_detail;
+        -- DROP INDEX  idx_visit_detail_concept_id ON visit_detail;
+
+        DROP INDEX  idx_procedure_person_id ON procedure_occurrence;
+        DROP INDEX  idx_procedure_concept_id ON procedure_occurrence;
+        DROP INDEX  idx_procedure_visit_id ON procedure_occurrence;
+
+        DROP INDEX  idx_drug_person_id ON drug_exposure;
+        DROP INDEX  idx_drug_concept_id ON drug_exposure;
+        DROP INDEX  idx_drug_visit_id ON drug_exposure;
+
+        DROP INDEX  idx_device_person_id ON device_exposure;
+        DROP INDEX  idx_device_concept_id ON device_exposure;
+        DROP INDEX  idx_device_visit_id ON device_exposure;
+
+        DROP INDEX  idx_condition_person_id ON condition_occurrence;
+        DROP INDEX  idx_condition_concept_id ON condition_occurrence;
+        DROP INDEX  idx_condition_visit_id ON condition_occurrence;
+
+        DROP INDEX  idx_measurement_person_id ON measurement;
+        DROP INDEX  idx_measurement_concept_id ON measurement;
+        DROP INDEX  idx_measurement_visit_id ON measurement;
+
+        DROP INDEX  idx_note_person_id ON note;
+        DROP INDEX  idx_note_concept_id ON note;
+        DROP INDEX  idx_note_visit_id ON note;
+
+        DROP INDEX  idx_note_nlp_note_id ON note_nlp;
+        DROP INDEX  idx_note_nlp_concept_id ON note_nlp;
+
+        DROP INDEX  idx_observation_person_id ON observation;
+        DROP INDEX  idx_observation_concept_id ON observation;
+        DROP INDEX  idx_observation_visit_id ON observation;
+
+        DROP INDEX  idx_fact_relationship_id_1 ON fact_relationship;
+        DROP INDEX  idx_fact_relationship_id_2 ON fact_relationship;
+        DROP INDEX  idx_fact_relationship_id_3 ON fact_relationship;
+
+
+
+        /************************
+        Standardized health system data
+        ************************/
+
+
+
+
+
+        /************************
+        Standardized health economics
+        ************************/
+
+        DROP INDEX  idx_period_person_id ON payer_plan_period;
+
+
+
+
+
+        /************************
+        Standardized derived elements
+        ************************/
+
+
+        DROP INDEX  idx_cohort_subject_id ON cohort;
+        DROP INDEX  idx_cohort_c_definition_id ON cohort;
+
+        DROP INDEX  idx_ca_subject_id ON cohort_attribute;
+        DROP INDEX  idx_ca_definition_id ON cohort_attribute;
+
+        DROP INDEX  idx_drug_era_person_id ON drug_era;
+        DROP INDEX  idx_drug_era_concept_id ON drug_era;
+
+        DROP INDEX  idx_dose_era_person_id ON dose_era;
+        DROP INDEX  idx_dose_era_concept_id ON dose_era;
+
+        DROP INDEX  idx_condition_era_person_id ON condition_era;
+        DROP INDEX  idx_condition_era_concept_id ON condition_era;
+END

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -150,11 +150,24 @@ resource "azurerm_mssql_database" "OHDSI-CDMV5" {
         command = "sqlcmd -U omop_admin -P ${var.omop_password} -S ${var.prefix}-${var.environment}-omop-sql-server.database.windows.net -d ${var.prefix}_${var.environment}_omop_db -i '../sql/OMOP_CDM_sql_server_ddl.sql' -o ${var.log_file}"
   }
 
-  # optionally create staging tables to aid in loading clinical data into the CDM
+  # optionally create staging tables and SPROCs to aid in loading clinical data into the CDM
   /*
   provisioner "local-exec" {
         command = "sqlcmd -U omop_admin -P ${var.omop_password} -S ${var.prefix}-${var.environment}-omop-sql-server.database.windows.net -d ${var.prefix}_${var.environment}_omop_db -i '../sql/OMOP_CDM_sql_server_staging_ddl.sql' -o ${var.log_file}"
   }
+
+  provisioner "local-exec" {
+        command = "sqlcmd -U omop_admin -P ${var.omop_password} -S ${var.prefix}-${var.environment}-omop-sql-server.database.windows.net -d ${var.prefix}_${var.environment}_omop_db -i '../sql/SPROC_add_indexes_constraints.sql' -o ${var.log_file}"
+  }
+
+  provisioner "local-exec" {
+        command = "sqlcmd -U omop_admin -P ${var.omop_password} -S ${var.prefix}-${var.environment}-omop-sql-server.database.windows.net -d ${var.prefix}_${var.environment}_omop_db -i '../sql/SPROC_remove_indexes_constraints.sql' -o ${var.log_file}"
+  }
+
+  provisioner "local-exec" {
+        command = "sqlcmd -U omop_admin -P ${var.omop_password} -S ${var.prefix}-${var.environment}-omop-sql-server.database.windows.net -d ${var.prefix}_${var.environment}_omop_db -i '../sql/SPROC_move_data_to_permanent_tables.sql' -o ${var.log_file}"
+  }
+  */
 
   # import cdm v5 vocabulary
   provisioner "local-exec" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -150,6 +150,12 @@ resource "azurerm_mssql_database" "OHDSI-CDMV5" {
         command = "sqlcmd -U omop_admin -P ${var.omop_password} -S ${var.prefix}-${var.environment}-omop-sql-server.database.windows.net -d ${var.prefix}_${var.environment}_omop_db -i '../sql/OMOP_CDM_sql_server_ddl.sql' -o ${var.log_file}"
   }
 
+  # optionally create staging tables to aid in loading clinical data into the CDM
+  /*
+  provisioner "local-exec" {
+        command = "sqlcmd -U omop_admin -P ${var.omop_password} -S ${var.prefix}-${var.environment}-omop-sql-server.database.windows.net -d ${var.prefix}_${var.environment}_omop_db -i '../sql/OMOP_CDM_sql_server_staging_ddl.sql' -o ${var.log_file}"
+  }
+
   # import cdm v5 vocabulary
   provisioner "local-exec" {
         command = "../scripts/vocab_import.sh ${var.prefix}-${var.environment}-omop-sql-server.database.windows.net ${var.prefix}_${var.environment}_omop_db omop_admin ${var.omop_password}"


### PR DESCRIPTION
This adds an optional sql script that is responsible for creating staging tables for the OMOP Clinical Tables. These staging tables can be used in a process to load clinical data in to the CDM where, new clinical data can be added to the target staging table and eventually migrated to the permanent clinical table using a SQL Stored Procedure or an alternative approach.